### PR TITLE
Hatch 644 walkthrough

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,11 @@ import { Stack } from '@twilio-paste/core/stack';
 import { Heading } from '@twilio-paste/core/heading';
 import { Paragraph } from '@twilio-paste/core/paragraph';
 import { Anchor } from '@twilio-paste/core/anchor';
+import { Alert } from '@twilio-paste/core/alert';
+import { Text } from '@twilio-paste/core/text';
+import { OrderedList, UnorderedList, ListItem } from '@twilio-paste/core/list';
+import { Disclosure, DisclosureHeading, DisclosureContent } from '@twilio-paste/core/disclosure';
+import { Separator } from '@twilio-paste/core/separator';
 
 import { PrototypeAnchor } from '../components/site/PrototypeAnchor';
 import { Code } from '../components/site/Code';
@@ -16,71 +21,170 @@ export default function Home() {
       <Heading as="h1" variant="heading10">
         Welcome to the Paste Prototyping Kit
       </Heading>
+      <Separator orientation="horizontal" verticalSpacing="space50" />
+      <Heading as="h2" variant="heading20">
+        Getting Started
+      </Heading>
+      <Paragraph>
+        Build your first prototype, an <strong>&quot;About Me&quot;</strong> page, by following our step-by-step guide.
+      </Paragraph>
+      <Box marginBottom="space40">
+        <Alert variant="warning">
+          <Text>
+            <strong>Only edit files in the &apos;pages&apos; folder.</strong> It contains everything necessary to build
+            your prototype.
+          </Text>
+        </Alert>
+      </Box>
+      <Stack orientation="vertical" spacing="space60">
+        <Card>
+          <Heading as="h3" variant="heading30">
+            1. Create your New Page
+          </Heading>
+          <Paragraph>
+            A page is created for every file in the <Code>pages</Code> folder. The easiest way to create a new page is
+            by duplicating an existing one.
+          </Paragraph>
+          <Paragraph>
+            Make a new page using <strong>&quot;Template Page&quot;</strong>:
+            <OrderedList>
+              <ListItem>
+                Create a new file in the <Code>pages</Code> folder.
+              </ListItem>
+              <ListItem>
+                Name the file <Code>about-me.js</Code>{' '}
+              </ListItem>
+              <ListItem>
+                Go to the <Code>template-page.js</Code> file and copy all of its contents.
+              </ListItem>
+              <ListItem>
+                Paste the contents into your <Code>about-me.js</Code> file
+              </ListItem>
+            </OrderedList>
+          </Paragraph>
+          <Paragraph>Congratulations! You just made your first new page on Paste.</Paragraph>
+          <Disclosure>
+            <DisclosureHeading as="h4" variant="heading50">
+              More Details
+            </DisclosureHeading>
+            <DisclosureContent>
+              <UnorderedList>
+                <ListItem>
+                  If you are working on your local machine (not CodeSandbox), you can simply duplicate the{' '}
+                  <Code>template-page.js</Code> file and rename it to <strong> &quot;about-me&quot;</strong>.
+                </ListItem>
+                <ListItem>
+                  You can visit your new page by appending the file name to your URL. For example, going to{' '}
+                  <strong>/about-me</strong> will show you the page created by the <Code>about-me.js</Code> file.
+                </ListItem>
+                <ListItem>
+                  To use one of the included patterns, duplicate that pattern&apos;s file instead of{' '}
+                  <Code>template-page.js</Code> and follow the instructions on the pattern&apos;s page.
+                </ListItem>
+              </UnorderedList>
+            </DisclosureContent>
+          </Disclosure>
+        </Card>
+        <Card>
+          <Heading as="h3" variant="heading30">
+            2. Add your New Page to the Navigation
+          </Heading>
+          <Paragraph>
+            To navigate to your new &quot;About Me&quot; page, a link to it must be included in the navigation bar.
+            Links for the navigation are edited in the <Code>pages.json</Code> file in the <Code>pages</Code> folder.
+          </Paragraph>
+          <Paragraph>
+            To add a link to the <strong>&quot;About Me&quot;</strong> page:
+            <OrderedList>
+              <ListItem>
+                Open the <Code>pages.json</Code> file.
+              </ListItem>
+              <ListItem>
+                Find the last list item- currently <Code>&quot;template-page&quot;: []</Code> - and add a comma to the
+                end of the line, so that it reads <Code>&quot;template-page&quot;: [],</Code>. Then press return to make
+                a new line.
+              </ListItem>
+              <ListItem>
+                Type in <Code>&quot;about-me&quot;: []</Code> in the new line.
+                <Paragraph>
+                  Make sure the the string in quotes matches the file name of the page you&apos;re linking to. In this
+                  demo, the file for the &quot;About Me&quot; page is called <Code>about-me.js</Code>.
+                </Paragraph>
+              </ListItem>
+            </OrderedList>
+          </Paragraph>
+          <Paragraph>Once you save your work, a new &quot;About Me&quot; link will pop up in the navigation!</Paragraph>
+          <Disclosure>
+            <DisclosureHeading as="h4" variant="heading50">
+              More Details
+            </DisclosureHeading>
+            <DisclosureContent>
+              <UnorderedList>
+                <ListItem>
+                  <strong>Commas matter here!</strong> If you are adding to the middle of the list, end your new line
+                  with a comma. If you are adding to the end of the list, the last list item should not end with a
+                  comma. When you encounter errors adding to the <Code>pages</Code> folder, check comma placement first.
+                </ListItem>
+                <ListItem>
+                  You can nest navigation links, so that a <strong>parent</strong> link opens up below a list of{' '}
+                  <strong>child</strong> links inside the navigation bar. You will need a folder inside the{' '}
+                  <Code>pages</Code> folder with the same name as the &quot;parent&quot; link, with the pages of the
+                  &quot;children&quot; links inside. To add this to the navigation:
+                  <UnorderedList>
+                    <ListItem>
+                      Use the above instructions to add a line to the <Code>pages.json</Code> file for the parent folder
+                      name.
+                    </ListItem>
+                    <ListItem>
+                      Add the file names of the &quot;children&quot; links into the brackets. Separate multiple file
+                      with commas.
+                    </ListItem>
+                    <ListItem>
+                      Save your work. If errors occur, check your commas in the file (detailed above).
+                    </ListItem>
+                  </UnorderedList>
+                </ListItem>
+              </UnorderedList>
+            </DisclosureContent>
+          </Disclosure>
+        </Card>
+        <Card>
+          <Heading as="h3" variant="heading30">
+            3. Follow your New Link
+          </Heading>
+          <Paragraph>
+            Finish your demo by clicking on your new <strong>&quot;About Me&quot;</strong> navigation link to edit the
+            page&apos;s contents.
+          </Paragraph>
+        </Card>
+      </Stack>
+      <Separator orientation="horizontal" verticalSpacing="space200" />
+      <Heading as="h2" variant="heading30">
+        About the Paste Prototyping Kit
+      </Heading>
       <Paragraph>
         The prototyping kit is a{' '}
         <PrototypeAnchor showExternal href="https://nextjs.org/">
           NextJS
         </PrototypeAnchor>{' '}
         app with Paste preloaded. It has everything you will need to create a fully functioning web based prototype
-        using Paste components
+        using Paste components.
       </Paragraph>
-      <Grid gutter="space40" marginBottom="space70" equalColumnHeights>
-        <Column>
-          <Card>
-            <Heading as="h3" variant="heading30">
-              Creating pages
-            </Heading>
-            <Paragraph>
-              Create pages in the <Code>pages</Code> directory. You can copy the <Code>template-page.js</Code> file and
-              rename it as <Code>my-new-page.js</Code> to get you going. The name of the file in the <Code>pages</Code>{' '}
-              directory will result in a route of the same name. e.g. <Code>my-new-page.js</Code> =&gt;{' '}
-              <Code>/my-new-page</Code>.
-            </Paragraph>
-          </Card>
-        </Column>
-        <Column>
-          <Card>
-            <Heading as="h3" variant="heading30">
-              Adding to the side nav
-            </Heading>
-            <Paragraph>
-              To add a link to a new page in the side bar, add the new page&apos;s file name to the pages.json file in
-              the <Code>pages</Code> directory. Make sure it is in quotes and followed by <Code>: []</Code>. For
-              example:
-            </Paragraph>
-            <Paragraph>
-              <Code>&quot;my-new-page&quot;: []</Code>
-            </Paragraph>
-            <Paragraph>
-              <strong>Note:</strong> if you are adding to the middle of the list, end the new line with a comma. If it
-              is the last list item, do not end the line with a comma.
-            </Paragraph>
-          </Card>
-        </Column>
-        <Column>
-          <Card>
-            <Heading as="h3" variant="heading30">
-              Linking between pages
-            </Heading>
-            <Paragraph>
-              <strong>Internal linking: </strong>Use the <Code>&lt;PrototypeAnchor /&gt;</Code> not the Paste Anchor. It
-              is a wrapper around the Paste Anchor suitable for NextJS websites. It looks and behaves exactly like a{' '}
-              <PrototypeAnchor href="https://paste.twilio.design/components/anchor" showExternal>
-                Paste Anchor
-              </PrototypeAnchor>
-              .
-            </Paragraph>
-          </Card>
-        </Column>
-      </Grid>
-      <Heading as="h2" variant="heading20">
-        Ways to get started
-      </Heading>
-      <Paragraph>The prototyping kit can be quickly deployed to the following platforms:</Paragraph>
+      <Paragraph>
+        <strong>Edit your prototype </strong>right in your browser using CodeSandbox
+      </Paragraph>
+      <Anchor display="inline-flex" href="https://githubbox.com/twilio-labs/paste-prototype-kit">
+        <Box
+          marginBottom="space80"
+          as="img"
+          src="https://codesandbox.io/static/img/play-codesandbox.svg"
+          alt="Edit in Codesandbox"
+        />
+      </Anchor>
+      <Paragraph>
+        <strong>Share your prototype quickly</strong> by deploying it using Vercel or Netlify:
+      </Paragraph>
       <Stack orientation="horizontal" spacing="space40">
-        <Anchor display="inline-flex" href="https://githubbox.com/twilio-labs/paste-prototype-kit">
-          <Box as="img" src="https://codesandbox.io/static/img/play-codesandbox.svg" alt="Edit in Codesandbox" />
-        </Anchor>
         <Anchor
           display="inline-flex"
           href="https://vercel.com/import/project?template=https://github.com/twilio-labs/paste-prototype-kit/tree/main"

--- a/pages/template-page.js
+++ b/pages/template-page.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import { Heading } from '@twilio-paste/core/heading';
 import { Paragraph } from '@twilio-paste/core/paragraph';
+import { Card } from '@twilio-paste/core/card';
+import { OrderedList, UnorderedList, ListItem } from '@twilio-paste/core/list';
+import { Stack } from '@twilio-paste/core/stack';
+import { Alert } from '@twilio-paste/core/alert';
+import { Text } from '@twilio-paste/core/text';
+import { Box } from '@twilio-paste/core/box';
+import { Disclosure, DisclosureHeading, DisclosureContent } from '@twilio-paste/core/disclosure';
 
 import { PrototypeAnchor } from '../components/site/PrototypeAnchor';
+import { Code } from '../components/site/Code';
 
 export default function Home() {
   return (
@@ -10,9 +18,219 @@ export default function Home() {
       <Heading as="h1" variant="heading10">
         Template Page
       </Heading>
-      <Paragraph>
-        Back to home <PrototypeAnchor href="/">Home</PrototypeAnchor>.
-      </Paragraph>
+      <Box marginBottom="space40">
+        <Alert variant="neutral">
+          <Text>
+            <strong>
+              Finish steps 1-3 on the <PrototypeAnchor href="/">home</PrototypeAnchor> page
+            </strong>{' '}
+            to learn about creating pages and navigation links.
+          </Text>
+        </Alert>
+      </Box>
+      <Stack orientation="vertical" spacing="space60">
+        <Card>
+          <Heading as="h3" variant="heading30">
+            4. Edit Page Content
+          </Heading>
+          <Paragraph>
+            To edit content on a page, go to its file in the <Code>pages</Code> folder. If you&apos;re following along
+            with the demo, this is an <strong>&quot;About Me&quot;</strong> page with the wrong title. Let&apos;s change
+            that.
+          </Paragraph>
+          <Paragraph>
+            To edit the title of this page:
+            <OrderedList>
+              <ListItem>
+                Open the <Code>about-me</Code> file created in step 1.
+              </ListItem>
+              <ListItem>
+                Find the first &lt;Heading&gt; component in the file. It will have the words{' '}
+                <strong>Template Page</strong> inside the &lt;Heading&gt; tags.
+              </ListItem>
+              <ListItem>
+                Replace the words <strong>Template Page</strong> with <strong>About Me</strong>.
+              </ListItem>
+            </OrderedList>
+          </Paragraph>
+          <Paragraph>
+            Once you save your work, the page title will change to <strong>&quot;About Me&quot;</strong>!
+          </Paragraph>
+          <Disclosure>
+            <DisclosureHeading as="h4" variant="heading50">
+              More Details
+            </DisclosureHeading>
+            <DisclosureContent>
+              <UnorderedList>
+                <ListItem>
+                  You can verify the page&apos;s corresponding file name by looking at its URL. For example, to edit a
+                  page with a /about-me URL, edit the <Code>about-me.js</Code> file.
+                </ListItem>
+                <ListItem>
+                  If you have trouble finding a component on a page, search for it using ctrl/cmd + f.
+                </ListItem>
+              </UnorderedList>
+            </DisclosureContent>
+          </Disclosure>
+        </Card>
+        <Card>
+          <Heading as="h3" variant="heading30">
+            5. Add New Content
+          </Heading>
+          <Paragraph>
+            A Paste component <strong>must be imported</strong> at the top of a file to be used in that file (and show
+            up on that page). Go to the{' '}
+            <PrototypeAnchor showExternal href="https://paste.twilio.design/components">
+              Paste Docs
+            </PrototypeAnchor>
+            for a full list of components you can add.
+          </Paragraph>
+          <Paragraph>To practice, let&apos;s add in a &lt;Separator&gt; component</Paragraph>
+          <Paragraph>
+            To add a component to the <strong>&quot;About Me&quot;</strong> page:
+            <OrderedList>
+              <ListItem>
+                Find the import statements at the top of the <Code>about-me.js</Code> file.
+              </ListItem>
+              <ListItem>
+                Add the new component&apos;s import statement below the existing ones. For the &lt;Separator&gt;
+                component, this statement is{' '}
+                <Code>import &#123; Separator &#125; from &apos;@twilio-paste/core/separator&apos;;</Code>
+              </ListItem>
+              <ListItem>
+                Add the component itself into the code. For the &lt;Separator&gt; component, make a new line after the
+                closing tag of the Heading component you edited in step 3 (looks like <Code>&lt;/Heading&gt;</Code>).
+                Then copy the following code and paste it into the new line:{' '}
+                <Code>&lt;Separator orientation=&quot;horizontal&quot; verticalSpacing=&quot;space50&quot; /&gt;</Code>
+              </ListItem>
+            </OrderedList>
+            <Paragraph>
+              Once you save your work, a thin, horizontal separator line will appear beneath your heading!
+            </Paragraph>
+          </Paragraph>
+          <Disclosure>
+            <DisclosureHeading as="h4" variant="heading50">
+              More Details
+            </DisclosureHeading>
+            <DisclosureContent>
+              <UnorderedList>
+                <ListItem>
+                  You can adjust components by changing their properties, also called props. In the{' '}
+                  <strong>Separator</strong> component, verticalSpacing is a prop. Adjust it to &quot;space100&quot;
+                  instead of &quot;space50&quot; to see what happens.{' '}
+                  <PrototypeAnchor showExternal href="https://paste.twilio.design/components/separator">
+                    More about Separator
+                  </PrototypeAnchor>
+                </ListItem>
+                <ListItem>
+                  Be careful when adding content from one page to another. You must have{' '}
+                  <strong>import statements for every component</strong> used on a page. When copying and pasting
+                  patterns, include the imports.
+                </ListItem>
+              </UnorderedList>
+            </DisclosureContent>
+          </Disclosure>
+        </Card>
+        <Card>
+          <Heading as="h3" variant="heading30">
+            6. Connect Pages Internally
+          </Heading>
+          <Paragraph>
+            Connect different pages in this kit to each other by using the &lt;PrototypeAnchor&gt; component to create
+            links.
+          </Paragraph>
+          <Paragraph>
+            To practice, let&apos;s add a link to this page that leads back to the <strong>&quot;Home&quot;</strong>{' '}
+            page.
+          </Paragraph>
+          <Paragraph>
+            To add a link in the <strong>&quot;About Me&quot;</strong> page for the <strong>&quot;Home&quot;</strong>{' '}
+            page:
+            <OrderedList>
+              <ListItem>
+                Create a new line under the closing tag of the &lt;Heading&gt; component in the <Code>about-me.js</Code>{' '}
+                file.
+              </ListItem>
+              <ListItem>
+                Add the &lt;PrototypeAnchor&gt; component by copying the following code and pasting it into the new
+                line:
+                <Code>&lt;PrototypeAnchor&gt;&lt;/PrototypeAnchor&gt;</Code>
+              </ListItem>
+              <ListItem>
+                Add the text of the link to the inside of the &lt;PrototypeAnchor&gt; component tags. For a link that
+                says &quot;Go to Home&quot;, the component should now read:{' '}
+                <Code>&lt;PrototypeAnchor&gt;Go to Home&lt;/PrototypeAnchor&gt;</Code>
+              </ListItem>
+              <ListItem>
+                Add a reference for the page the link leads to. The home page has the reference &quot;/&quot;. Specify
+                the reference by adding <Code>href=&quot;/&quot;</Code> inside of the opening &lt;PrototypeAnchor&gt;
+                component tag. It should now read:{' '}
+                <Code>&lt;PrototypeAnchor href=&quot;/&quot;&gt;Go to Home&lt;/PrototypeAnchor&gt;</Code>
+              </ListItem>
+            </OrderedList>
+            <Paragraph>Save your work and click on the link to check that it works!</Paragraph>
+          </Paragraph>
+          <Disclosure>
+            <DisclosureHeading as="h4" variant="heading50">
+              More Details
+            </DisclosureHeading>
+            <DisclosureContent>
+              <UnorderedList>
+                <ListItem>
+                  References to internal pages (pages in this kit) match the file structure of the <Code>pages</Code>{' '}
+                  folder. For example:
+                  <UnorderedList>
+                    <ListItem>
+                      &quot;/about-me&quot; refers to the page made by the <Code>about-me.js</Code> file. You can link
+                      to it by using <Code>href=&quot;/about-me&quot;</Code>.
+                    </ListItem>
+                    <ListItem>
+                      For nested pages, include the name of the parent folder before the name of the child page. For
+                      example: <Code>href=&quot;/phone-numbers/active-numbers&quot;</Code> would refer to a page made by
+                      a <Code>active-numbers.js</Code> file inside of a <Code>phone-numbers</Code> folder (all this
+                      inside the <Code>pages</Code> folder).
+                    </ListItem>
+                  </UnorderedList>
+                </ListItem>
+                <ListItem>
+                  <strong>To link to an external page,</strong> include the string <Code>showExternal</Code> inside of
+                  the opening &lt;PrototypeAnchor&gt; component tag, and refer to the full URL of the page you&apos;re
+                  linking to. The component for an external link to the Paste Docs looks like:{' '}
+                  <Code>
+                    &lt;PrototypeAnchor showExternal href=&quot;https://paste.twilio.design/&quot;&gt;The Paste
+                    Docs&lt;/PrototypeAnchor&gt;
+                  </Code>
+                </ListItem>
+                <ListItem>
+                  Make sure that an <strong>import statement</strong> exists for the &lt;PrototypeAnchor&gt; component
+                  before using it. This component is specific to the prototyping kit, so its import statement will look
+                  a little different. Use this code snippet if there is no import statement for the
+                  &lt;PrototypeAnchor&gt; component in your file:
+                  <Code>import &#123; PrototypeAnchor &#125; from &apos;../components/site/PrototypeAnchor&apos;;</Code>
+                  . <strong>Note:</strong> this import statement will need to be adjusted for nested &quot;child&quot;
+                  pages to include another &quot;../&quot; at the beginning of the string following <Code>from</Code>.
+                </ListItem>
+              </UnorderedList>
+            </DisclosureContent>
+          </Disclosure>
+        </Card>
+        <Card>
+          <Heading as="h3" variant="heading30">
+            7. Check Out Patterns
+          </Heading>
+          <Paragraph>Reusable patterns are created from putting many components together for a specific use.</Paragraph>
+          <Paragraph>
+            Go to the <PrototypeAnchor href="/patterns/delete">delete pattern</PrototypeAnchor> page or the{' '}
+            <PrototypeAnchor href="/patterns/create-standard">create pattern</PrototypeAnchor> page to learn about using
+            them in your prototype.
+          </Paragraph>
+          <Paragraph>
+            <PrototypeAnchor showExternal href="https://paste.twilio.design/patterns">
+              More about patterns
+            </PrototypeAnchor>
+          </Paragraph>
+        </Card>
+      </Stack>
     </>
   );
 }


### PR DESCRIPTION
Updated the landing page to include an interactive, step-by-step demo to make an "About Me" page. Steps include

1. Make a new page
2. Make a link to that new page
3. Navigate to that new page using the link
4. Edit the page's title
5. Add a new component to that page

Step 5 was going to be adding a pattern to the page, but it got overly complicated, since we can't just copy and paste the entire page's content and have two return statements. Scaled back to adding a simple component (Separator) to the page so that the user gets used to importing.

Also pushed the info about the kit itself (it's made w/ NextJS, can be deployed using Vercel...) to the bottom so users don't do THAT first.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
